### PR TITLE
cvideo_data.pio for non-zero pin_base

### DIFF
--- a/cvideo_data.pio
+++ b/cvideo_data.pio
@@ -45,6 +45,7 @@ void cvideo_data_initialise_pio(PIO pio, uint sm, uint offset, uint pin_base, ui
     pio_sm_set_consecutive_pindirs(pio, sm, pin_base, pin_count, true);
     pio_sm_config c = cvideo_data_program_get_default_config(offset);
     sm_config_set_out_pins(&c, pin_base, pin_count);
+    sm_config_set_in_pins(&c, pin_base);                                // Set input pins for non-zero pin_base
     sm_config_set_out_shift(&c, false, true, 8);
     pio_sm_init(pio, sm, offset, &c);
     pio->sm[sm].clkdiv = (uint32_t) (freq * (1 << 16));


### PR DESCRIPTION
Currently if the pin-base is not zero the wrong data is read into Y at the start of the loop meaning the border if not restored at the end. This corrects that problem.