### PR TITLE
Fix row 0 being drawn at the bottom of the screen instead of row 1

### DIFF
--- a/cvideo.c
+++ b/cvideo.c
@@ -279,9 +279,13 @@ void cvideo_dma_handler(void) {
 
         // Then the border scanlines
         //
-        case 6 ... 68:
+        case 6 ... 67:
         case 261 ... 309:
             dma_channel_set_read_addr(dma_channel_0, border, true);
+            break;
+        case 68:    // Last top-border line: re-anchor bline so bitmap[0] is at top
+            dma_channel_set_read_addr(dma_channel_0, border, true);
+            bline = 1;
             break;
 
         // Now point the dma at the first buffer for the pixel data,

--- a/cvideo.c
+++ b/cvideo.c
@@ -279,9 +279,14 @@ void cvideo_dma_handler(void) {
 
         // Then the border scanlines
         //
-        case 6 ... 68:
+        case 6 ... 67:
         case 261 ... 309:
             dma_channel_set_read_addr(dma_channel_0, border, true);
+            break;
+        case 68:    // Last top-border line: preload pixel DMA with bitmap[0] so y=0 is at the top
+            dma_channel_set_read_addr(dma_channel_0, border, true);
+            bline = 1;
+            dma_channel_set_read_addr(dma_channel_1, bitmap, true);
             break;
 
         // Now point the dma at the first buffer for the pixel data,

--- a/cvideo.c
+++ b/cvideo.c
@@ -279,14 +279,9 @@ void cvideo_dma_handler(void) {
 
         // Then the border scanlines
         //
-        case 6 ... 67:
+        case 6 ... 68:
         case 261 ... 309:
             dma_channel_set_read_addr(dma_channel_0, border, true);
-            break;
-        case 68:    // Last top-border line: preload pixel DMA with bitmap[0] so y=0 is at the top
-            dma_channel_set_read_addr(dma_channel_0, border, true);
-            bline = 1;
-            dma_channel_set_read_addr(dma_channel_1, bitmap, true);
             break;
 
         // Now point the dma at the first buffer for the pixel data,


### PR DESCRIPTION
 Fix scanline order: y=0 renders at bottom of screen instead of top:

Easy to replicate:
cls(0):
line_draw(0, 0, 255, 0, 15);
line_draw(0, 1, 255, 1, 15);

Code should draw thick line to the top of the screen, instead it draws thin line to the top and to the bottom (default resolution).

cvideo_configure_pio_dma() for the pixel channel starts the DMA immediately with a NULL source, which puts bytes from address 0x0 into the PIO TX FIFO before bitmap is even set up. This creates a one-line pipeline slip: bitmap[0] ends up on the last active scanline (bottom) and bitmap[1] on the first (top).

Fix: split case 6 ... 68 in cvideo_dma_handler to handle vline 68 separately. On that last top-border line — one full scan period (~64µs) before the first active line — reset bline and preload dma_channel_1 with bitmap[0].

Note: a comment at case 3 ("Also on scanline 3, preload the first pixel buffer scanline") indicates this was the original intent but was never implemented?
